### PR TITLE
add -a|--autodetect option

### DIFF
--- a/gres_config_gen
+++ b/gres_config_gen
@@ -6,6 +6,7 @@ NUM_CORES=$(nproc)
 NAME="gpu"
 HEADER_FILENAME=""
 PRINT_USAGE=0
+AUTODETECT=""
 
 while [[ $# -gt 0 ]]
 do
@@ -22,6 +23,11 @@ do
 			shift
 			shift
 			;;
+		-a|--autodetect)
+			AUTODETECT="$2"
+			shift
+			shift
+			;;
 		-u|--usage|*)
 			PRINT_USAGE=1
 			shift
@@ -32,7 +38,7 @@ done
 
 if [ $PRINT_USAGE -eq 1 ];then
 	echo "Usage:"
-	echo "gres_conf_gen [-n|--name DeviceName [Default:gpu]] [-h|--header HeaderFileName [Default:none]]"
+	echo "gres_conf_gen [-n|--name DeviceName [Default:gpu]] [-h|--header HeaderFileName [Default:none]] [-a|--autodetect AutoDetectOption [Default:none]]"
 	exit 1
 fi
 
@@ -46,3 +52,7 @@ do
 	end_core=$((($gpu + 1) * $NUM_CORES / $NUM_GPUS - 1))
 	printf "Name=%-10s File=/dev/nvidia%d CPUs=%d-%d\n" $NAME $gpu $start_core $end_core
 done
+
+if [[ -n "$AUTODETECT" ]]; then
+    echo "AutoDetect=$AUTODETECT"
+fi


### PR DESCRIPTION
In recent versions of Slurm, the Gres plugin includes an AutoDetect feature.   
It appears that the configuration generated by this script can sometimes conflict with AutoDetect.   
In fact, when using the new version of Slurm, the following error occurred in slurmctld:  
```
slurmctld[753]: slurmctld: error: _node_config_validate: gres/gpu: invalid GRES core specification (24-47) on node ***
```
Disabling AutoDetect by setting AutoDetect=off resolved the issue.   
I’ve added a feature to this script that allows setting the AutoDetect option to avoid such conflicts.  

### Example
For example, running the following command:
```
./gres_config_gen --autodetect off
```
Will result in the output:
```
Name=gpu        File=/dev/nvidia0 CPUs=0-23
Name=gpu        File=/dev/nvidia1 CPUs=24-47
AutoDetect=off
```